### PR TITLE
Navbar highlight

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,6 +1,0 @@
-from flask import Flask
-
-app = Flask(__name__)
-
-from app import routes
-

--- a/app/static/js/trends.js
+++ b/app/static/js/trends.js
@@ -3,7 +3,7 @@ const tooltip = d3.select("body").append("div").attr("class", "toolTip");
 //// svgHourly
 
 const margin = {top: 20, right: 20, bottom: 30, left: 50},
-    width = 1000 - margin.left - margin.right,
+    width = 500 - margin.left - margin.right,
     height = 250 - margin.top - margin.bottom;
 
 const xHourly = d3.scaleLinear().range([0, width]);

--- a/app/static/js/trends.js
+++ b/app/static/js/trends.js
@@ -53,60 +53,50 @@ let svgMonthly = d3.select("#monthly")
     .append("g")
     .attr("transform",`translate(${margin.left}, ${margin.top})`);
 
-//// Render Plots 
+// Render Plots 
 renderTrendPlots()
 
-// Render Hourly Plot 
-async function renderTrendPlots(){
+function renderTrendPlots(){
+  renderHourly();
+  renderMonthly();
 
-  const dataHourly = await d3.json("hourlyTrendData");
-  const dataMonthly = await d3.json("monthlyTrendData");
+};
 
-  dataHourly.forEach( d => {
+async function renderHourly(){
+
+  const data = await d3.json("hourlyTrendData");
+
+  data.forEach( d => {
     d.hour = +d.hour;
     d.totalCasualties = +d.totalCasualties;
     d.fatalCasualties = +d.fatalCasualties;
 
   });
-
-  dataMonthly.forEach( d => {
-    d.month = +d.month;
-    d.totalCasualties = +d.totalCasualties;
-    d.fatalCasualties = +d.fatalCasualties;
-
-  });
-
-  // set domain 
-  xHourly.domain(d3.extent(dataHourly.map(d => d.hour)));
-  yHourly.domain([0, d3.max(dataHourly.map(d => d.totalCasualties))]);
-
-  xMonthly.domain(d3.extent(dataMonthly.map(d => d.month)));
-  yMonthly.domain([0, d3.max(dataMonthly.map(d => d.totalCasualties))]);
-
+  
   // create the lines 
-  let lineCasualtiesHourly = d3.line()
+  let lineCasualties = d3.line()
     .x(d => {return xHourly(d.hour); })
     .y(d => {return yHourly(d.totalCasualties); });
 
-  let lineFatalitiesHourly = d3.line()
+  let lineFatalities = d3.line()
     .x(d => {return xHourly(d.hour); })
     .y(d => {return yHourly(d.fatalCasualties); });
 
-  let lineCasualtiesMonthly = d3.line()
-    .x(d => {return xMonthly(d.month); })
-    .y(d => {return yMonthly(d.totalCasualties); });
+  // set domain 
+  xHourly.domain(d3.extent(data.map(d => d.hour)));
+  yHourly.domain([0, d3.max(data.map(d => d.totalCasualties))]);
 
-  let lineFatalitiesMonthly = d3.line()
-    .x(d => {return xMonthly(d.month); })
-    .y(d => {return yMonthly(d.fatalCasualties); });
-
-  // Calls a function that adds the line paths, axes, labels, and title
-  addPathsAxesLabels(dataHourly, svgHourly, lineCasualtiesHourly, lineFatalitiesHourly, xHourly, yHourly, lineCasualtiesLabelHourlyY, lineFatalitiesLabelHourlyY, svgHourlyTitleY, svgHourlyTitle, svgHourlyXLabelY, svgHourlyXLabel);
-  addPathsAxesLabels(dataMonthly, svgMonthly, lineCasualtiesMonthly, lineFatalitiesMonthly, xMonthly, yMonthly, lineCasualtiesLabelMonthlyY, lineFatalitiesLabelMonthlyY, svgMonthlyTitleY, svgMonthlyTitle, svgMonthlyXLabelY, svgMonthlyXLabel);
+  // Add the lineCasualties path
+  svgHourly.append("path")
+    .data([data])
+    .style("fill", "none")
+    .style("stroke", "steelblue")
+    .attr("class", "line")
+    .attr("d", lineCasualties);
   
   // Dots for lineCasualties
   svgHourly.selectAll(".dotCasualties")
-    .data(dataHourly)
+    .data(data)
     .enter().append("circle")
       .attr("class", "dotCasualties")
       .attr("cx", d => {return xHourly(d.hour); })
@@ -120,24 +110,17 @@ async function renderTrendPlots(){
           .html(`Hour: ${d.hour} <br>Casualties: ${d.totalCasualties}`);})
       .on("mouseout", d => { tooltip.style("display", "none");});
 
-  svgMonthly.selectAll(".dotCasualties")
-    .data(dataMonthly)
-    .enter().append("circle")
-      .attr("class", "dotCasualties")
-      .attr("cx", d => {return xMonthly(d.month) })
-      .attr("cy", d => {return yMonthly(d.totalCasualties) })
-      .attr("r", circleRadius)
-      .on("mousemove", d => {
-        tooltip
-          .style("left", d3.event.pageX - tooltipLeftPadding + "px")
-          .style("top", d3.event.pageY - tooltipTopPadding + "px")
-          .style("display", "inline-block")
-          .html(`Month: ${d.month} <br>Casualties: ${d.totalCasualties}`);})
-      .on("mouseout", d => {tooltip.style("display", "none");});
+  // Add the lineFatalities path
+  svgHourly.append("path")
+    .data([data])
+    .style("fill", "none")
+    .style("stroke", "red")
+    .attr("class", "line")
+    .attr("d", lineFatalities);
   
   // Dots for lineFatalities
   svgHourly.selectAll(".dotFatalities")
-    .data(dataHourly)
+    .data(data)
     .enter().append("circle")
       .attr("class", "dotFatalities")
       .attr("cx", d => { return xHourly(d.hour) })
@@ -150,9 +133,107 @@ async function renderTrendPlots(){
           .style("display", "inline-block")
           .html(`Hour: ${d.hour} <br>Fatalities: ${d.fatalCasualties}`);})
       .on("mouseout", d => { tooltip.style("display", "none");}); 
+  
+  // Add the X Axis
+  svgHourly.append("g")
+    .attr("transform", `translate(0, ${height})`)
+    .call(d3.axisBottom(xHourly));
 
+  // Add the Y Axis
+  svgHourly.append("g")
+    .call(d3.axisLeft(yHourly));
+  
+  // lineCasualties Label
+  svgHourly.append("text")
+    .attr("class", "lineCasualtiesLabel")
+    .attr("transform", `translate(${lineCasualtiesLabelX}, ${lineCasualtiesLabelHourlyY})`)
+    .attr("dy", ".35em")
+    .text(lineCasualtiesLabel);
+  
+  // lineFatalities Label
+  svgHourly.append("text")
+    .attr("class", "lineFatalitiesLabel")
+    .attr("transform", `translate(${lineFatalitiesLabelX}, ${lineFatalitiesLabelHourlyY})`)
+    .attr("dy", ".35em")
+    .text(lineFatalitiesLabel);
+
+  // Title
+  svgHourly.append("text")
+    .attr("class", "title")
+    .attr("transform", `translate(0, ${svgHourlyTitleY})`)
+    .attr("dy", ".35em")
+    .text(svgHourlyTitle);
+
+  // X-Axis Label
+  svgHourly.append("text")
+    .attr("class", "xAxisLabel")
+    .attr("transform", `translate(${xLabelX}, ${svgHourlyXLabelY})`)
+    .attr("dy", ".35em")
+    .text(svgHourlyXLabel);
+
+}
+
+
+// Render Monthly Plot
+async function renderMonthly(){
+
+  const data = await d3.json("monthlyTrendData");
+
+  data.forEach( d => {
+    d.month = +d.month;
+    d.totalCasualties = +d.totalCasualties;
+    d.fatalCasualties = +d.fatalCasualties;
+
+  });
+
+  // Set the domains
+  xMonthly.domain(d3.extent(data.map(d => d.month)));
+  yMonthly.domain([0, d3.max(data.map(d => d.totalCasualties))]);
+  
+  // create the lines 
+  let lineCasualties = d3.line()
+    .x(d => {return xMonthly(d.month); })
+    .y(d => {return yMonthly(d.totalCasualties); });
+
+  let lineFatalities = d3.line()
+    .x(d => {return xMonthly(d.month); })
+    .y(d => {return yMonthly(d.fatalCasualties); });
+
+  // Add the lineCasualties path
+  svgMonthly.append("path")
+    .data([data])
+    .style("fill", "none")
+    .style("stroke", "steelblue")
+    .attr("class", "line")
+    .attr("d", lineCasualties);
+  
+  // Dots for lineCasualties
+  svgMonthly.selectAll(".dotCasualties")
+    .data(data)
+    .enter().append("circle")
+      .attr("class", "dotCasualties")
+      .attr("cx", d => {return xMonthly(d.month) })
+      .attr("cy", d => {return yMonthly(d.totalCasualties) })
+      .attr("r", circleRadius)
+      .on("mousemove", d => {
+        tooltip
+          .style("left", d3.event.pageX - tooltipLeftPadding + "px")
+          .style("top", d3.event.pageY - tooltipTopPadding + "px")
+          .style("display", "inline-block")
+          .html(`Month: ${d.month} <br>Casualties: ${d.totalCasualties}`);})
+      .on("mouseout", d => {tooltip.style("display", "none");});
+
+  // Add the lineFatalities path
+  svgMonthly.append("path")
+    .data([data])
+    .style("fill", "none")
+    .style("stroke", "red")
+    .attr("class", "line")
+    .attr("d", lineFatalities); 
+  
+  // Dots for lineFatalities
   svgMonthly.selectAll(".dotFatalities")
-    .data(dataMonthly)
+    .data(data)
     .enter().append("circle") 
       .attr("class", "dotFatalities") 
       .attr("cx", d => {return xMonthly(d.month) })
@@ -165,61 +246,41 @@ async function renderTrendPlots(){
           .style("display", "inline-block")
           .html(`Month: ${d.month} <br>Fatalities: ${d.fatalCasualties}`);})
       .on("mouseout", d => {tooltip.style("display", "none");}); 
+  
+  // Add the X Axis
+  svgMonthly.append("g")
+    .attr("transform", `translate(0,${height})`)
+    .call(d3.axisBottom(xMonthly));
 
-}
-
-function addPathsAxesLabels(data, svg, lineCasualties, lineFatalities, xScale, yScale, lineCasualtiesLabelY, lineFatalitiesLabelY, svgTitleY, svgTitle, svgXLabelY, svgXLabel){
-  // Add the lineCasualties path
-  svg.append("path")
-    .data([data])
-    .style("fill", "none")
-    .style("stroke", "steelblue")
-    .attr("class", "line")
-    .attr("d", lineCasualties);
-
-  // Add the lineFatalities path
-  svg.append("path")
-    .data([data])
-    .style("fill", "none")
-    .style("stroke", "red")
-    .attr("class", "line")
-    .attr("d", lineFatalities);
-
-  // Add the X-Axis
-  svg.append("g")
-    .attr("transform", `translate(0, ${height})`)
-    .call(d3.axisBottom(xScale));
-
-  // Add the Y-Axis
-  svg.append("g")
-    .call(d3.axisLeft(yScale));
-
-  // Add the lineCasualties label
-  svg.append("text")
+  // Add the Y Axis
+  svgMonthly.append("g")
+    .call(d3.axisLeft(yMonthly));
+  
+  // lineCasualties Label
+  svgMonthly.append("text")
     .attr("class", "lineCasualtiesLabel")
-    .attr("transform", `translate(${lineCasualtiesLabelX}, ${lineCasualtiesLabelY})`)
+    .attr("transform", `translate(${lineCasualtiesLabelX},${lineCasualtiesLabelMonthlyY})`)
     .attr("dy", ".35em")
     .text(lineCasualtiesLabel);
 
-  // Add the lineFatalities label
-  svg.append("text")
+  // lineFatalities Label
+  svgMonthly.append("text")
     .attr("class", "lineFatalitiesLabel")
-    .attr("transform", `translate(${lineFatalitiesLabelX}, ${lineFatalitiesLabelY})`)
+    .attr("transform", `translate(${lineFatalitiesLabelX},${lineFatalitiesLabelMonthlyY})`)
     .attr("dy", ".35em")
     .text(lineFatalitiesLabel);
-
-  // Add the title
-  svg.append("text")
+  
+  // Title
+  svgMonthly.append("text")
     .attr("class", "title")
-    .attr("transform", `translate(0, ${svgTitleY})`)
+    .attr("transform", `translate(0,${svgMonthlyTitleY})`)
     .attr("dy", ".35em")
-    .text(svgTitle);
+    .text(svgMonthlyTitle);
 
-  // Add the X-Axis label
-  svg.append("text")
+  // X-Axis Label
+  svgMonthly.append("text")
     .attr("class", "xAxisLabel")
-    .attr("transform", `translate(${xLabelX}, ${svgXLabelY})`)
+    .attr("transform", `translate(${xLabelX},${svgMonthlyXLabelY})`)
     .attr("dy", ".35em")
-    .text(svgXLabel);
-
-};
+    .text(svgMonthlyXLabel);
+}

--- a/app/static/js/trends.js
+++ b/app/static/js/trends.js
@@ -1,11 +1,39 @@
-const tooltip = d3.select("body").append("div").attr("class", "toolTip");
-
-//// svgHourly
-
+// Constants
 const margin = {top: 20, right: 20, bottom: 30, left: 50},
     width = 500 - margin.left - margin.right,
     height = 250 - margin.top - margin.bottom;
+const tooltip = d3.select("body").append("div").attr("class", "toolTip");
+const tooltipLeftPadding = 50;
+const tooltipTopPadding = 70;
+// line labels
+const lineCasualtiesLabel = "Total Casualties";
+const lineFatalitiesLabel = "Total Fatalities";
+// X position of line labels
+const lineCasualtiesLabelX = width-57;
+const lineFatalitiesLabelX = width-50;
+//Y position for the line labels 
+const lineCasualtiesLabelHourlyY = 35;
+const lineFatalitiesLabelHourlyY = 105;
+const lineCasualtiesLabelMonthlyY = 0;
+const lineFatalitiesLabelMonthlyY = 80;
+// plot titles
+const svgHourlyTitle = "Total Number of Casualties and Fatalities by Hour of Day";
+const svgMonthlyTitle = "Total Number of Casualties and Fatalities by Month";
+// Y position of titles
+const svgHourlyTitleY = -10;
+const svgMonthlyTitleY = -10;
+// X-axis labels
+const svgHourlyXLabel = "Hour of Day";
+const svgMonthlyXLabel = "Month";
+// X Position of x-axis labels
+const xLabelX = .5*width;
+// Y Position of x-axis labels
+const svgHourlyXLabelY = height+23;
+const svgMonthlyXLabelY = height+23;
+// radius of dots on lines
+const circleRadius = 3;
 
+// svgHourly
 const xHourly = d3.scaleLinear().range([0, width]);
 const yHourly = d3.scaleLinear().range([height, 0]);
 
@@ -15,8 +43,7 @@ let svgHourly = d3.select("#hourly")
     .append("g")
     .attr("transform",`translate(${margin.left}, ${margin.top})`);
 
-//// svgMonthly
-
+// svgMonthly
 const xMonthly = d3.scaleLinear().range([0, width]);
 const yMonthly = d3.scaleLinear().range([height, 0]); 
 
@@ -27,230 +54,172 @@ let svgMonthly = d3.select("#monthly")
     .attr("transform",`translate(${margin.left}, ${margin.top})`);
 
 //// Render Plots 
-renderHourly()
-renderMonthly()
+renderTrendPlots()
 
 // Render Hourly Plot 
-async function renderHourly(){
+async function renderTrendPlots(){
 
-  const data = await d3.json("hourlyTrendData");
+  const dataHourly = await d3.json("hourlyTrendData");
+  const dataMonthly = await d3.json("monthlyTrendData");
 
-  data.forEach( d => {
+  dataHourly.forEach( d => {
     d.hour = +d.hour;
     d.totalCasualties = +d.totalCasualties;
     d.fatalCasualties = +d.fatalCasualties;
 
   });
-  
-  // create the lines 
-  let lineCasualties = d3.line()
-    .x(d => {return xHourly(d.hour); })
-    .y(d => {return yHourly(d.totalCasualties); });
 
-  let lineFatalities = d3.line()
-    .x(d => {return xHourly(d.hour); })
-    .y(d => {return yHourly(d.fatalCasualties); });
-
-  // set domain 
-  xHourly.domain(d3.extent(data.map(d => d.hour)));
-  yHourly.domain([0, d3.max(data.map(d => d.totalCasualties))]);
-
-  // Add the lineCasualties path
-  svgHourly.append("path")
-    .data([data])
-    .style("fill", "none")
-    .style("stroke", "steelblue")
-    .attr("class", "line")
-    .attr("d", lineCasualties);
-  
-  // Dots for lineCasualties
-  svgHourly.selectAll(".dotCasualties")
-    .data(data)
-    .enter().append("circle")
-      .attr("class", "dotCasualties")
-      .attr("cx", d => {return xHourly(d.hour); })
-      .attr("cy", d => {return yHourly(d.totalCasualties); })
-      .attr("r", 3)
-      .on("mousemove", d => {
-        tooltip
-          .style("left", d3.event.pageX - 50 + "px")
-          .style("top", d3.event.pageY - 70 + "px")
-          .style("display", "inline-block")
-          .html(`Hour: ${d.hour} <br>Casualties: ${d.totalCasualties}`);})
-      .on("mouseout", d => { tooltip.style("display", "none");});
-
-  // Add the lineFatalities path
-  svgHourly.append("path")
-    .data([data])
-    .style("fill", "none")
-    .style("stroke", "red")
-    .attr("class", "line")
-    .attr("d", lineFatalities);
-  
-  // Dots for lineFatalities
-  svgHourly.selectAll(".dotFatalities")
-    .data(data)
-    .enter().append("circle")
-      .attr("class", "dotFatalities")
-      .attr("cx", d => { return xHourly(d.hour) })
-      .attr("cy", d => { return yHourly(d.fatalCasualties) })
-      .attr("r", 3)
-      .on("mousemove", d => {
-        tooltip
-          .style("left", d3.event.pageX - 50 + "px")
-          .style("top", d3.event.pageY - 70 + "px")
-          .style("display", "inline-block")
-          .html(`Hour: ${d.hour} <br>Fatalities: ${d.fatalCasualties}`);})
-      .on("mouseout", d => { tooltip.style("display", "none");}); 
-  
-  // Add the X Axis
-  svgHourly.append("g")
-    .attr("transform", `translate(0, ${height})`)
-    .call(d3.axisBottom(xHourly));
-
-  // Add the Y Axis
-  svgHourly.append("g")
-    .call(d3.axisLeft(yHourly));
-  
-  // lineCasualties Label
-  svgHourly.append("text")
-    .attr("class", "lineCasualtiesLabel")
-    .attr("transform", `translate(${width-57}, ${yHourly(860)})`)
-    .attr("dy", ".35em")
-    .text("Total Casualties");
-  
-  // lineFatalities Label
-  svgHourly.append("text")
-    .attr("class", "lineFatalitiesLabel")
-    .attr("transform", `translate(${(width-50)}, ${yHourly(480)})`)
-    .attr("dy", ".35em")
-    .text("Total Fatalities");
-
-  // Title
-  svgHourly.append("text")
-    .attr("class", "title")
-    .attr("transform", `translate(${(0)}, ${yHourly(1100)})`)
-    .attr("dy", ".35em")
-    .text("Total Number of Casualties and Fatalities by Hour of Day");
-
-  // X-Axis Label
-  svgHourly.append("text")
-    .attr("class", "xAxisLabel")
-    .attr("transform", `translate(${(.5*width)}, ${yHourly(-120)})`)
-    .attr("dy", ".35em")
-    .text("Hour of Day");
-
-}
-
-
-// Render Monthly Plot
-async function renderMonthly(){
-
-  const data = await d3.json("monthlyTrendData");
-
-  data.forEach( d => {
+  dataMonthly.forEach( d => {
     d.month = +d.month;
     d.totalCasualties = +d.totalCasualties;
     d.fatalCasualties = +d.fatalCasualties;
 
   });
 
-  // Set the domains
-  xMonthly.domain(d3.extent(data.map(d => d.month)));
-  yMonthly.domain([0, d3.max(data.map(d => d.totalCasualties))]);
-  
+  // set domain 
+  xHourly.domain(d3.extent(dataHourly.map(d => d.hour)));
+  yHourly.domain([0, d3.max(dataHourly.map(d => d.totalCasualties))]);
+
+  xMonthly.domain(d3.extent(dataMonthly.map(d => d.month)));
+  yMonthly.domain([0, d3.max(dataMonthly.map(d => d.totalCasualties))]);
+
   // create the lines 
-  let lineCasualties = d3.line()
+  let lineCasualtiesHourly = d3.line()
+    .x(d => {return xHourly(d.hour); })
+    .y(d => {return yHourly(d.totalCasualties); });
+
+  let lineFatalitiesHourly = d3.line()
+    .x(d => {return xHourly(d.hour); })
+    .y(d => {return yHourly(d.fatalCasualties); });
+
+  let lineCasualtiesMonthly = d3.line()
     .x(d => {return xMonthly(d.month); })
     .y(d => {return yMonthly(d.totalCasualties); });
 
-  let lineFatalities = d3.line()
+  let lineFatalitiesMonthly = d3.line()
     .x(d => {return xMonthly(d.month); })
     .y(d => {return yMonthly(d.fatalCasualties); });
 
+  // Calls a function that adds the line paths, axes, labels, and title
+  addPathsAxesLabels(dataHourly, svgHourly, lineCasualtiesHourly, lineFatalitiesHourly, xHourly, yHourly, lineCasualtiesLabelHourlyY, lineFatalitiesLabelHourlyY, svgHourlyTitleY, svgHourlyTitle, svgHourlyXLabelY, svgHourlyXLabel);
+  addPathsAxesLabels(dataMonthly, svgMonthly, lineCasualtiesMonthly, lineFatalitiesMonthly, xMonthly, yMonthly, lineCasualtiesLabelMonthlyY, lineFatalitiesLabelMonthlyY, svgMonthlyTitleY, svgMonthlyTitle, svgMonthlyXLabelY, svgMonthlyXLabel);
+  
+  // Dots for lineCasualties
+  svgHourly.selectAll(".dotCasualties")
+    .data(dataHourly)
+    .enter().append("circle")
+      .attr("class", "dotCasualties")
+      .attr("cx", d => {return xHourly(d.hour); })
+      .attr("cy", d => {return yHourly(d.totalCasualties); })
+      .attr("r", circleRadius)
+      .on("mousemove", d => {
+        tooltip
+          .style("left", d3.event.pageX - tooltipLeftPadding + "px")
+          .style("top", d3.event.pageY - tooltipTopPadding + "px")
+          .style("display", "inline-block")
+          .html(`Hour: ${d.hour} <br>Casualties: ${d.totalCasualties}`);})
+      .on("mouseout", d => { tooltip.style("display", "none");});
+
+  svgMonthly.selectAll(".dotCasualties")
+    .data(dataMonthly)
+    .enter().append("circle")
+      .attr("class", "dotCasualties")
+      .attr("cx", d => {return xMonthly(d.month) })
+      .attr("cy", d => {return yMonthly(d.totalCasualties) })
+      .attr("r", circleRadius)
+      .on("mousemove", d => {
+        tooltip
+          .style("left", d3.event.pageX - tooltipLeftPadding + "px")
+          .style("top", d3.event.pageY - tooltipTopPadding + "px")
+          .style("display", "inline-block")
+          .html(`Month: ${d.month} <br>Casualties: ${d.totalCasualties}`);})
+      .on("mouseout", d => {tooltip.style("display", "none");});
+  
+  // Dots for lineFatalities
+  svgHourly.selectAll(".dotFatalities")
+    .data(dataHourly)
+    .enter().append("circle")
+      .attr("class", "dotFatalities")
+      .attr("cx", d => { return xHourly(d.hour) })
+      .attr("cy", d => { return yHourly(d.fatalCasualties) })
+      .attr("r", circleRadius)
+      .on("mousemove", d => {
+        tooltip
+          .style("left", d3.event.pageX - tooltipLeftPadding + "px")
+          .style("top", d3.event.pageY - tooltipTopPadding + "px")
+          .style("display", "inline-block")
+          .html(`Hour: ${d.hour} <br>Fatalities: ${d.fatalCasualties}`);})
+      .on("mouseout", d => { tooltip.style("display", "none");}); 
+
+  svgMonthly.selectAll(".dotFatalities")
+    .data(dataMonthly)
+    .enter().append("circle") 
+      .attr("class", "dotFatalities") 
+      .attr("cx", d => {return xMonthly(d.month) })
+      .attr("cy", d => {return yMonthly(d.fatalCasualties) })
+      .attr("r", circleRadius)
+      .on("mousemove", d => {
+        tooltip
+          .style("left", d3.event.pageX - tooltipLeftPadding + "px")
+          .style("top", d3.event.pageY - tooltipTopPadding + "px")
+          .style("display", "inline-block")
+          .html(`Month: ${d.month} <br>Fatalities: ${d.fatalCasualties}`);})
+      .on("mouseout", d => {tooltip.style("display", "none");}); 
+
+}
+
+function addPathsAxesLabels(data, svg, lineCasualties, lineFatalities, xScale, yScale, lineCasualtiesLabelY, lineFatalitiesLabelY, svgTitleY, svgTitle, svgXLabelY, svgXLabel){
   // Add the lineCasualties path
-  svgMonthly.append("path")
+  svg.append("path")
     .data([data])
     .style("fill", "none")
     .style("stroke", "steelblue")
     .attr("class", "line")
     .attr("d", lineCasualties);
-  
-  // Dots for lineCasualties
-  svgMonthly.selectAll(".dotCasualties")
-    .data(data)
-    .enter().append("circle")
-      .attr("class", "dotCasualties")
-      .attr("cx", d => {return xMonthly(d.month) })
-      .attr("cy", d => {return yMonthly(d.totalCasualties) })
-      .attr("r", 3)
-      .on("mousemove", d => {
-        tooltip
-          .style("left", d3.event.pageX - 50 + "px")
-          .style("top", d3.event.pageY - 70 + "px")
-          .style("display", "inline-block")
-          .html(`Month: ${d.month} <br>Casualties: ${d.totalCasualties}`);})
-      .on("mouseout", d => {tooltip.style("display", "none");});
 
   // Add the lineFatalities path
-  svgMonthly.append("path")
+  svg.append("path")
     .data([data])
     .style("fill", "none")
     .style("stroke", "red")
     .attr("class", "line")
-    .attr("d", lineFatalities); 
-  
-  // Dots for lineFatalities
-  svgMonthly.selectAll(".dotFatalities")
-    .data(data)
-    .enter().append("circle") 
-      .attr("class", "dotFatalities") 
-      .attr("cx", d => {return xMonthly(d.month) })
-      .attr("cy", d => {return yMonthly(d.fatalCasualties) })
-      .attr("r", 3)
-      .on("mousemove", d => {
-        tooltip
-          .style("left", d3.event.pageX - 50 + "px")
-          .style("top", d3.event.pageY - 70 + "px")
-          .style("display", "inline-block")
-          .html(`Month: ${d.month} <br>Fatalities: ${d.fatalCasualties}`);})
-      .on("mouseout", d => {tooltip.style("display", "none");}); 
-  
-  // Add the X Axis
-  svgMonthly.append("g")
-    .attr("transform", `translate(0,${height})`)
-    .call(d3.axisBottom(xMonthly));
+    .attr("d", lineFatalities);
 
-  // Add the Y Axis
-  svgMonthly.append("g")
-    .call(d3.axisLeft(yMonthly));
-  
-  // lineCasualties Label
-  svgMonthly.append("text")
+  // Add the X-Axis
+  svg.append("g")
+    .attr("transform", `translate(0, ${height})`)
+    .call(d3.axisBottom(xScale));
+
+  // Add the Y-Axis
+  svg.append("g")
+    .call(d3.axisLeft(yScale));
+
+  // Add the lineCasualties label
+  svg.append("text")
     .attr("class", "lineCasualtiesLabel")
-    .attr("transform", `translate(${width-57},${yMonthly(1450)})`)
+    .attr("transform", `translate(${lineCasualtiesLabelX}, ${lineCasualtiesLabelY})`)
     .attr("dy", ".35em")
-    .text("Total Casualties");
+    .text(lineCasualtiesLabel);
 
-  // lineFatalities Label
-  svgMonthly.append("text")
+  // Add the lineFatalities label
+  svg.append("text")
     .attr("class", "lineFatalitiesLabel")
-    .attr("transform", `translate(${width-50},${yMonthly(860)})`)
+    .attr("transform", `translate(${lineFatalitiesLabelX}, ${lineFatalitiesLabelY})`)
     .attr("dy", ".35em")
-    .text("Total Fatalities");
-  
-  // Title
-  svgMonthly.append("text")
+    .text(lineFatalitiesLabel);
+
+  // Add the title
+  svg.append("text")
     .attr("class", "title")
-    .attr("transform", `translate(${0},${yMonthly(1550)})`)
+    .attr("transform", `translate(0, ${svgTitleY})`)
     .attr("dy", ".35em")
-    .text("Total Number of Casualties and Fatalities by Month");
+    .text(svgTitle);
 
-  // X-Axis Label
-  svgMonthly.append("text")
+  // Add the X-Axis label
+  svg.append("text")
     .attr("class", "xAxisLabel")
-    .attr("transform", `translate(${.5*width},${yMonthly(-175)})`)
+    .attr("transform", `translate(${xLabelX}, ${svgXLabelY})`)
     .attr("dy", ".35em")
-    .text("Month");
-}
+    .text(svgXLabel);
 
+};

--- a/app/static/js/type.js
+++ b/app/static/js/type.js
@@ -4,7 +4,7 @@ const margin = {top: 20, right: 20, bottom: 20, left: 70},
   width = 1000 - margin.left - margin.right,
   height = 250 - margin.top - margin.bottom;
 
-//// FATALITY COUNT BY AGE: svgFatalCountAge
+// FATALITY COUNT BY AGE: svgFatalCountAge
 
 const xFatalCountAge = d3.scaleBand().rangeRound([0, width]).padding(.1);
 const yFatalCountAge = d3.scaleLinear().rangeRound([height, 0]);
@@ -15,7 +15,7 @@ let svgFatalCountAge = d3.select("#fatalCountAge")
   .append("g")
   .attr("transform",`translate(${margin.left}, ${margin.top})`);
 
-//// FATALITY TYPE BY AGE: svgFatalTypeAge
+// FATALITY TYPE BY AGE: svgFatalTypeAge
 
 const xFatalTypeAge = d3.scaleLinear().range([0, width]);
 const yFatalTypeAge = d3.scalePoint().rangeRound([height, 0]);
@@ -27,7 +27,7 @@ let svgFatalTypeAge = d3.select("#fatalTypeAge")
   .attr("transform",`translate(${margin.left}, ${margin.top})`);
 
 
-//// FATALITY TYPE BY COUNT: svgFatalTypeCount
+// FATALITY TYPE BY COUNT: svgFatalTypeCount
 
 const xFatalTypeCount = d3.scaleBand().rangeRound([0, width]).padding(.1);
 const yFatalTypeCount = d3.scaleLinear().rangeRound([height, 0]);
@@ -38,21 +38,31 @@ let svgFatalTypeCount = d3.select("#fatalTypeCount")
   .append("g")
   .attr("transform",`translate(${margin.left}, ${margin.top})`);
 
-//// If we want All to be checked when "Age and Types" load and have graphs show up 
-//// need to figure out text 
-//// change "All" radio button to checked
-// let selection = "All";
-// let fill = "mediumseagreen";
-// updateFatalCountAge(selection, fill);
-// updateFatalTypeAge(selection, fill);
-// updateFatalTypeCount(selection, fill);
+// "All" already selected/output when /type is loaded
+let selection = "All";
+let fill = "mediumseagreen";
+updateFatalCountAge(selection, fill);
+updateFatalTypeAge(selection, fill);
+updateFatalTypeCount(selection, fill);
 
-//// BUTTON/GRAPH UPDATES
+let textFatalCountAgeMale ="While being less than 15, the number of fatalities is relatively low. This starts to increase drastically around age 15-16. In the United Kingdom, the legal driving age is 17 but teenagers can receive learning permits around the age of 16. The age with the highest fatal casualty count for the population is 18 with 325 fatalities. After age 18, the number of fatalities decreases almost as drastically as it increased before. There is a more subtle decrease from ages 40 to 70, with a slight increase from the late 70s and into the 80s where we see it decrease again.";
+let textFatalTypeCountMale ="Fatal Casualty Type consists of which vehicle and what role the fatal casualty was playing in the vehicle at the time of the accident. This varies from being a pedestrian, a van passenger, or a bus driver. Overall, the four highest fatal casualty types for the entire population were car driver, pedestrian, motorcycle rider, and car passenger. Out of the total number of fatalities, these top four account for 90%. Car driver alone accounts for 33% of the fatal casualty types.";
+let textFatalTypeAgeMale ="How the most frequent fatality type changes with age follows the general life of a person. From the age 0 to age 17, the most frequent alternates between pedestrian and car passenger. A year after driver's license eligibility, the most frequent changes to car driver. This continues into the mid 30s. 35 to 46 are the only ages where motorcycle rider is the most frequent fatality type. Afterward, the most frequent returns to car driver until 70, where it returns to pedestrian. ";
+
+d3.select("#textFatalCountAge").text(textFatalCountAgeMale);
+d3.select("#textFatalTypeAge").text(textFatalTypeAgeMale);
+d3.select("#textFatalTypeCount").text(textFatalTypeCountMale);
+
+// BUTTON/GRAPH UPDATES
 const buttons = d3.selectAll('input');
 buttons.on('change', (d,i,nodes) => {
   let selection = nodes[i].value;
   console.log(`button changed to ${selection}`);
   let fill;
+
+  let textFatalCountAge;
+  let textFatalTypeCount;
+  let textFatalTypeAge;
   
   // determine text and fill color for graphs
   // Sublime: View > Wrap Text
@@ -68,9 +78,10 @@ buttons.on('change', (d,i,nodes) => {
     textFatalTypeAge ="Text here for fatal type age for male:";
   } else{
     fill = "mediumseagreen";
-    textFatalCountAge ="While being less than 15, the number of fatalities is relatively low. This starts to increase drastically around age 15-16. In the United Kingdom, the legal driving age is 17 but teenagers can receive learning permits around the age of 16. The age with the highest fatal casualty count for the population is 18 with 325 fatalities. After age 18, the number of fatalities decreases almost as drastically as it increased before. There is a more subtle decrease from ages 40 to 70, with a slight increase from the late 70s and into the 80s where we see it decrease again.";
-    textFatalTypeCount ="Fatal Casualty Type consists of which vehicle and what role the fatal casualty was playing in the vehicle at the time of the accident. This varies from being a pedestrian, a van passenger, or a bus driver. Overall, the four highest fatal casualty types for the entire population were car driver, pedestrian, motorcycle rider, and car passenger. Out of the total number of fatalities, these top four account for 90%. Car driver alone accounts for 33% of the fatal casualty types.";
-    textFatalTypeAge ="How the most frequent fatality type changes with age follows the general life of a person. From the age 0 to age 17, the most frequent alternates between pedestrian and car passenger. A year after driver's license eligibility, the most frequent changes to car driver. This continues into the mid 30s. 35 to 46 are the only ages where motorcycle rider is the most frequent fatality type. Afterward, the most frequent returns to car driver until 70, where it returns to pedestrian. ";
+    textFatalCountAge = textFatalCountAgeMale;
+    textFatalTypeAge = textFatalTypeAgeMale;
+    textFatalTypeCount = textFatalTypeCountMale;
+
   }
   
   // select the text for div in html 
@@ -86,7 +97,7 @@ buttons.on('change', (d,i,nodes) => {
 });
 
 
-//// FATALITY COUNT BY AGE: svgFatalCountAge 
+// FATALITY COUNT BY AGE: svgFatalCountAge 
 
 async function updateFatalCountAge(selection, fill){
 
@@ -189,7 +200,7 @@ async function updateFatalCountAge(selection, fill){
 
 } 
 
-//// FATALITY TYPE BY AGE: svgFatalTypeAge
+// FATALITY TYPE BY AGE: svgFatalTypeAge
 
 async function updateFatalTypeAge(selection, fill){
   data = await d3.json(`fatalTypeAge/${selection}`);
@@ -297,7 +308,7 @@ async function updateFatalTypeAge(selection, fill){
 }
 
 
-//// FATALITY TYPE BY COUNT: svgFatalTypeCount
+// FATALITY TYPE BY COUNT: svgFatalTypeCount
 
 async function updateFatalTypeCount(selection, fill){
   data = await d3.json(`fatalityTypeCount/${selection}`);

--- a/app/static/js/type.js
+++ b/app/static/js/type.js
@@ -45,13 +45,13 @@ updateFatalCountAge(selection, fill);
 updateFatalTypeAge(selection, fill);
 updateFatalTypeCount(selection, fill);
 
-let textFatalCountAgeMale ="While being less than 15, the number of fatalities is relatively low. This starts to increase drastically around age 15-16. In the United Kingdom, the legal driving age is 17 but teenagers can receive learning permits around the age of 16. The age with the highest fatal casualty count for the population is 18 with 325 fatalities. After age 18, the number of fatalities decreases almost as drastically as it increased before. There is a more subtle decrease from ages 40 to 70, with a slight increase from the late 70s and into the 80s where we see it decrease again.";
-let textFatalTypeCountMale ="Fatal Casualty Type consists of which vehicle and what role the fatal casualty was playing in the vehicle at the time of the accident. This varies from being a pedestrian, a van passenger, or a bus driver. Overall, the four highest fatal casualty types for the entire population were car driver, pedestrian, motorcycle rider, and car passenger. Out of the total number of fatalities, these top four account for 90%. Car driver alone accounts for 33% of the fatal casualty types.";
-let textFatalTypeAgeMale ="How the most frequent fatality type changes with age follows the general life of a person. From the age 0 to age 17, the most frequent alternates between pedestrian and car passenger. A year after driver's license eligibility, the most frequent changes to car driver. This continues into the mid 30s. 35 to 46 are the only ages where motorcycle rider is the most frequent fatality type. Afterward, the most frequent returns to car driver until 70, where it returns to pedestrian. ";
+let textFatalCountAgeAll ="While being less than 15, the number of fatalities is relatively low. The number of fatalities starts to increase drastically around age 15-16. In the United Kingdom, the legal driving age is 17, but teenagers can receive learning permits around the age of 16. The age with the highest fatal casualty count for the population is 18 with 325 fatalities. After age 18, the number of fatalities decreases almost as drastically as it increased before. There is a more subtle decrease from ages 40 to 70, with a slight increase from the late 70s and into the 80s where we see it decrease again.";
+let textFatalTypeCountAll ="Fatal Casualty Type consists of which vehicle and what role the fatal casualty was playing in the vehicle at the time of the accident. Fatal Casualty Type varies from being a pedestrian or a van passenger to a bus driver. Overall, the four highest fatal casualty types for the entire population were car driver, pedestrian, motorcycle rider, and car passenger. Out of the total number of fatalities, these top four account for 90%. Car driver alone accounts for 33% of the 8,656 fatal casualties.";
+let textFatalTypeAgeAll ="How the most frequent fatality type changes with age follows the general life of a person. From the age 0 to 17, the most frequent alternates between pedestrian and car passenger. A year after driver's license eligibility, the most frequent changes to a car driver. Car driver continues into the mid-30s. 35 to 46 are the only ages where motorcycle rider is the most frequent fatality type. Afterward, the most frequent returns to car driver until 70, where it returns to a pedestrian. ";
 
-d3.select("#textFatalCountAge").text(textFatalCountAgeMale);
-d3.select("#textFatalTypeAge").text(textFatalTypeAgeMale);
-d3.select("#textFatalTypeCount").text(textFatalTypeCountMale);
+d3.select("#textFatalCountAge").text(textFatalCountAgeAll);
+d3.select("#textFatalTypeAge").text(textFatalTypeAgeAll);
+d3.select("#textFatalTypeCount").text(textFatalTypeCountAll);
 
 // BUTTON/GRAPH UPDATES
 const buttons = d3.selectAll('input');
@@ -68,19 +68,19 @@ buttons.on('change', (d,i,nodes) => {
   // Sublime: View > Wrap Text
   if (selection==="Female"){
     fill = "indianred";
-    textFatalCountAge ="Since females account for only 25% of all fatalities, the distribution of fatalities across ages remains similar but the amount of fatalities is smaller. The age with the highest fatal casualty count is 19 with only 72 fatalities. Comparing this distribution with the population and males, the females' has a more prominent increase around age 80.";
-    textFatalTypeCount ="The top three fatal casualty types for females are relatively close and only differ by 11 fatalities. There is a drastic change from third highest to fourth highest of 580 fatalities.";
-    textFatalTypeAge ="Text here about fatal type age for female";
+    textFatalCountAge ="Since females account for only 25% of all fatalities, the distribution of fatalities across ages remains similar, but the amount of fatalities is smaller. The age with the highest fatal casualty count is 19, with only 72 fatalities. Comparing this distribution with the population's and male's, the female's has a more noticeable increase around age 80.";
+    textFatalTypeCount ="Females have three distinct highest fatality types: pedestrian, car driver, and car passenger. These three fatality types are relatively close and only differ by 11 fatalities. There is a drastic change from the third highest to fourth highest of 580 fatalities. Pedestrian is the highest with 657 fatalities, while males had 1,236 pedestrian fatalities and it was only the third highest fatality type.";
+    textFatalTypeAge ="The top three fatality types are the only ones seen in the most frequent fatality type by age. A motorcycle rider was a most frequent fatality type for the entire population, but is not seen as a one for females. This is not surprising considering only 51 females fatalities are associated with being a motorcycle rider. Car passenger is overall the most frequent fatality type for females less than 18 years old. A car driver is the most frequent from ages 19 to 64 with a few pedestrians and car passenger fatality types appearing, also. After the age of 64, a pedestrian is the most frequent.";
   }else if (selection==="Male"){
     fill = "steelblue";
-    textFatalCountAge ="Since majority of fatalities are male, it males since why the male population follows the same age trend as the entire population. The fatal casualty count for people less than 14 is relatively low with an increase around age 15. The age with the highest fatal casualty count for males is 18 with 256 fatalities. Then, the fatal casualty count decrease into the late 20s. After age 40, overall, there is a steady decrease into the 90s.";
-    textFatalTypeCount ="Text here about fatal type age for male";
-    textFatalTypeAge ="Text here for fatal type age for male:";
+    textFatalCountAge ="Since the majority of fatalities are male, the male distributions look very similar to the distributions for the entire population. The fatal casualty count for people less than 14 is relatively low with an increase around age 15. The age with the highest fatal casualty count for males is 18 with 256 fatalities. Then, the fatal casualty count decreases into the late 20s. After age 40, overall, there is a steady decrease into the 90s.";
+    textFatalTypeCount ="The top four fatal casualty types are also the same for males as they were for the entire population: car driver, motorcycle rider, pedestrian, and car passenger. Motorcycle rider surpassed pedestrian as the second most fatal casualty type. Motorcycle rider now has 322 more fatalities than pedestrian, but for the entire population, motorcycle rider had 283 fewer fatalities compared to pedestrian.";
+    textFatalTypeAge ="There are three critical differences between the male's most frequent fatality type by age and the entire population's. The first is the occurrence of a pedal cyclist being most frequent for ages 9, 13, and 14. Pedal cyclist was not a most frequent fatality type for any age for the population. For the population, a motorcycle rider was the most frequent from ages 35 to 46, but for males it extends to the age 49 with a few more at 53 and 55, making it the second difference. Lastly, a car driver is mixed in as most frequent into the late 70s and through the early 90s. For the population, a car driver stopped around the age of 72. ";
   } else{
     fill = "mediumseagreen";
-    textFatalCountAge = textFatalCountAgeMale;
-    textFatalTypeAge = textFatalTypeAgeMale;
-    textFatalTypeCount = textFatalTypeCountMale;
+    textFatalCountAge = textFatalCountAgeAll;
+    textFatalTypeAge = textFatalTypeAgeAll;
+    textFatalTypeCount = textFatalTypeCountAll;
 
   }
   

--- a/app/templates/about.html
+++ b/app/templates/about.html
@@ -5,12 +5,9 @@
 {% block content %}
     <div style="margin-left: 40px; margin-right:40px;">
         <h2><p style = "font-family:arial"> About</p> </h2>
-         The United Kingdom's Department for Transport reported 7,981 fatal road accidents in Great Britain from 2006 to 2008. These accidents caused 15,429 total casualties, with 8,656 of those casualities being fatal. Each report included information about month and hour of accident, age and gender of the fatal casualty, and fatality type. 
+         The United Kingdom's Department for Transport reported 7,981 fatal road accidents in Great Britain from 2006 to 2008. These accidents caused 15,429 total casualties, with 8,656 of those casualties being fatal. Each report included information about month and hour of the accident, age and gender of the fatal casualty, and fatality type.
         <br>
         <br>
-         This dashboard contains data visualizations and analysis for the United Kingdom's Department for Transport Fatal Accident Report to see monthly and hourly time trends, if certain genders and ages have more fatal casualties than others, and which fatality type is most frequent. [insert interesting questions that will be answered or give a short summary of the findings]
-        <br>
-        <br>
-        Continue exploring the analysis in <a href="/trends">Trends</a> or <a href="/type">Age and Type</a>. 
+         This dashboard contains data visualizations and analysis for the United Kingdom's Department for Transport Fatal Accident Report to see monthly and hourly time trends, if certain genders and ages have more fatal casualties than others, and which fatality type is most frequent. Continue exploring the analysis in <a href="/trends">Trends</a> or <a href="/type">Age and Type</a>. 
     </div>
 {% endblock %}

--- a/app/templates/about.html
+++ b/app/templates/about.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% set active_page = "about" %}
+
 {% block content %}
     <div style="margin-left: 40px; margin-right:40px;">
         <h2><p style = "font-family:arial"> About</p> </h2>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -56,28 +56,6 @@
         </div>
     </nav>
 
-<!--     <nav class="navbar navbar-expand-lg navbar-light bg-light">
-        <a class="navbar-brand" href="#">Navbar</a>
-        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
-            <span class="navbar-toggler-icon"></span>
-        </button>
-        <div class="collapse navbar-collapse" id="navbarNav">
-            <ul class="navbar-nav">
-                <li class="nav-item active">
-                    <a class="nav-link" href="#">Home <span class="sr-only">(current)</span></a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link" href="#">Features</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link" href="#">Pricing</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link disabled" href="#">Disabled</a>
-                </li>
-            </ul>
-        </div>
-    </nav> -->
 {% endblock %}
 
 

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -11,7 +11,7 @@
         }
         /* "Great Britain Fatal Accidents" label text color */
         .navbar-default .navbar-brand {
-            color: #A9A9A9;
+            color: #BEBEBE;
         }
         /* "Great Britain Fatal Accidents" text color white when hover */
         .navbar-default .navbar-brand:hover, 
@@ -20,32 +20,64 @@
         }
         /* Other tabs label text color */
         .navbar-default .navbar-nav > li > a {
-            color: #A9A9A9;
+            color: #BEBEBE;
         }
         /* Other tabs label color white when hover */
         .navbar-default .navbar-nav > li > a:hover, 
         .navbar-default .navbar-nav > li > a:focus {
             color: #ecf0f1;
         }
+
+        .navbar-default .navbar-nav > .active > a {
+        	background-color:#404040; 
+        	color: #DCDCDC;
+        }
+
+        .navbar-default .navbar-nav > .active > a:hover,
+		.navbar-default .navbar-nav > .active > a:focus {
+			background-color:#404040;
+			color: #ecf0f1;
+		}
+
     </style>
     <nav class="navbar navbar-default">
         <div class="navbar-header">
             <button type="button" class="navbar-toggle" data-target="#navbar" aria-expanded="false">
-                <span class="sr-only">Toggle navigation </span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
+                <span class="navbar-toggler-icon"></span>
             </button>
             <a class="navbar-brand" href="/about">Great Britain Fatal Accidents</a>
         </div>
         <div class="collapse navbar-collapse" id="#navbar">
             <ul class="nav navbar-nav">
-                <li><a href="/about">About</a></li>
-                <li><a href="/trends">Trends</a></li>
-                <li><a href="/type">Age and Type</a></li>
+                <li class="{{ 'active' if active_page == 'about' else '' }}"><a href="/about">About</a></li>
+                <li class="{{ 'active' if active_page == 'trends' else '' }}"><a href="/trends">Trends</a></li>
+                <li class="{{ 'active' if active_page == 'type' else '' }}"><a href="/type">Age and Type</a></li>
             </ul>
         </div>
     </nav>
+
+<!--     <nav class="navbar navbar-expand-lg navbar-light bg-light">
+        <a class="navbar-brand" href="#">Navbar</a>
+        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarNav">
+            <ul class="navbar-nav">
+                <li class="nav-item active">
+                    <a class="nav-link" href="#">Home <span class="sr-only">(current)</span></a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="#">Features</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="#">Pricing</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link disabled" href="#">Disabled</a>
+                </li>
+            </ul>
+        </div>
+    </nav> -->
 {% endblock %}
 
 

--- a/app/templates/trends.html
+++ b/app/templates/trends.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% set active_page = "trends" %}
+
 {% block content %}
 <style>
   .dotCasualties {
@@ -64,27 +66,43 @@
   <div class="text">
     <h2><p>Trends</p> </h2>
     <p>Short description about the two trends that will be included</p>
-    <h4>Monthly Trends</h4>
-    We first look to see if any month have more fatalities or total caualties. In term of casualties, March is the lowest month and October is the highest. February is the month with the lowest number of fatalities and October is still the highest. 
     <br>
+    <h4>Monthly Trends</h4>
     <br>
   </div>
-  <div class="plot">
-    <svg id="monthly"></svg>
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-sm-6">
+        <div class="plot">
+          <svg id="monthly"></svg>
+        </div>
+      </div>
+      <div class="col-sm-6">
+        <div class="text">
+          We first look to see if any month have more fatalities or total caualties. In term of casualties, March is the lowest month and October is the highest. February is the month with the lowest number of fatalities and October is still the highest. 
+        </div>
+      </div>
+    </div>
   </div>
   <br>
   <div class="text">
     <h4>Hourly Trends</h4>
-    We can also break down number of casualties and fatalities by hour of the day. These graphs follow the time of day were most people are driving. The values for both casualities and fatalities are lowest in the morning hours. Around 6 a.m., both start to increase. This increase continues throughout the day until 6 p.m. when it starts to decline again. 
-    <br>
     <br>
   </div>
-  <div class="plot">
-    <svg id="hourly"></svg>
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-sm-6">
+        <div class="plot">
+          <svg id="hourly"></svg>
+        </div>
+      </div>
+      <div class="col-sm-6">
+        <div class="text">
+          We can also break down number of casualties and fatalities by hour of the day. These graphs follow the time of day were most people are driving. The values for both casualities and fatalities are lowest in the morning hours. Around 6 a.m., both start to increase. This increase continues throughout the day until 6 p.m. when it starts to decline again. 
+        </div>
+      </div>
+    </div>
   </div>
-  <br>
-  <br>
-  <br>
 
   <script src="https://d3js.org/d3.v5.min.js"></script>
 

--- a/app/templates/trends.html
+++ b/app/templates/trends.html
@@ -34,7 +34,8 @@
 
   .text{
     margin-left: 40px;
-    margin-right: 40px;}
+    margin-right: 40px;
+    font-family: arial;}
 
   .plot{
     margin-left:30px;
@@ -65,8 +66,7 @@
 <body>
   <div class="text">
     <h2><p>Trends</p> </h2>
-    <p>Short description about the two trends that will be included</p>
-    <br>
+    <p>Visualizing the trends shows the distribution of the 15,429 casualties and 8,656 fatalities across months of the year and hours of the day. By doing this, we can determine which months and hours held the most and least casualties and fatalities from the 2006 to 2008 reports.</p>
     <h4>Monthly Trends</h4>
     <br>
   </div>
@@ -79,7 +79,7 @@
       </div>
       <div class="col-sm-6">
         <div class="text">
-          We first look to see if any month have more fatalities or total caualties. In term of casualties, March is the lowest month and October is the highest. February is the month with the lowest number of fatalities and October is still the highest. 
+          While excluding January, the first half of the year has lower total casualties and fatalities when compared to the second half. March is the lowest month for the total number of casualties with 1,061. In regards to fatalities, though, February has the lowest count of 624. October holds the highest number of total casualties at 1,450 and also the highest number of fatalities with 821. 
         </div>
       </div>
     </div>
@@ -98,7 +98,7 @@
       </div>
       <div class="col-sm-6">
         <div class="text">
-          We can also break down number of casualties and fatalities by hour of the day. These graphs follow the time of day were most people are driving. The values for both casualities and fatalities are lowest in the morning hours. Around 6 a.m., both start to increase. This increase continues throughout the day until 6 p.m. when it starts to decline again. 
+          The hourly trend follows the time of day where most people would be driving. Hour 0 maps to midnight, with hour 12 being noon and hour 23 being 11:00 pm. The values for both casualties and fatalities are lowest in the morning hours. Around 5:00 am, both start to increase as people start traveling for the day. This increase continues throughout the day until 5:00 pm, when it starts to decline as people have reached their destinations for the day. 5:00 pm is the peak for total casualties at 1,031 but is tied for the highest number of fatalities with 4:00 pm at 554. 
         </div>
       </div>
     </div>

--- a/app/templates/type.html
+++ b/app/templates/type.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% set active_page = "type" %}
+
 {% block content %}
 
 <style>
@@ -41,7 +43,7 @@
     </p>
     <h5>Select an option:</h5>
     <form name="myForm">
-      <input type="radio" name="myRadios"  value="All" >     All     </value>
+      <input type="radio" name="myRadios"  value="All" checked >     All     </value>
       <input type="radio" name="myRadios"  value="Male" >     Male     </value>
       <input type="radio" name="myRadios"  value="Female" >     Female     </value>
     </form>

--- a/app/templates/type.html
+++ b/app/templates/type.html
@@ -39,7 +39,7 @@
 <body>
   <div class="text">
     <h2><p style = "font-family:arial">Age and Fatal Casualty Types</p></h2>
-    <p>Of the 8,656 fatal casualties reported, 2,155 were female, 6,500 were male, and one was unreported. Coupling this information with fatal casualty age, we can investigate whether certain ages and genders are more prone to fatalities and certain fatality types than others. After selecting an option for which population below, three graphs will appear. The first looks at the distribution of fatal casualties across ages. The second features the number of fatalities for each fatality type. And the last shows how the most frequent fatality type changes with age. 
+    <p>Of the 8,656 fatal casualties reported, 2,155 were female, 6,500 were male, and one was unreported. Coupling this information with fatal casualty age, we can investigate whether certain ages and genders were more prone to fatalities and certain fatality types than others. The three graphs below show different distributions for the selected population — the first looks at the diffusion of fatal casualties across ages. The second features the number of fatalities for each fatality type. And the last shows how the most frequent fatality type changes with age.
     </p>
     <h5>Select an option:</h5>
     <form name="myForm">
@@ -49,8 +49,8 @@
     </form>
     <br>
   </div>
-  <!-- Fatal Count by Age text and graph -->
-  <div class="text" style="width: 93%; height: 100px; background-color: #eee">
+  <!-- Fatal Count by Age text and graph 15%-->
+  <div class="text" style="width: 93%; height: 85px;">
     <p id="textFatalCountAge"></p>
   </div>
   <br>
@@ -60,7 +60,7 @@
   <br>
   <br>
   <!-- Fatal Type by Count text and graph -->
-  <div class="text" style="width: 93%; height: 100px; background-color: #eee">
+  <div class="text" style="width: 93%; height: 70px;">
     <p id="textFatalTypeCount"></p>
   </div>
   <br>
@@ -70,7 +70,7 @@
   <br>
   <br>
   <!-- Fatal Type by Age text and graph -->
-  <div class="text" style="width: 93%; height: 100px; background-color: #eee">
+  <div class="text" style="width: 93%; height: 75px;">
     <p id="textFatalTypeAge"></p>
   </div>
   <br>

--- a/project1.py
+++ b/project1.py
@@ -1,1 +1,0 @@
-from app import app


### PR DESCRIPTION
1. Navbar highlights which tab is open. Completed by changing the class of each item in navbar to an if statement to determine "active". Set an active_page variable on about.html, trends.html, and type.html

2. Set default for type.html. Now, when you navigate to /type, the "All" option is already selected with text and graphs for "All" showing up, too. To do this, I changed the All radio button on type.html to checked and added a few lines in type.js for the output to already be rendered before the buttons are clicked.

3. Not an issue Brooks created but I changed trends.html so each graph has text directly to the right instead of above/below.

4. Made a single function in trends.js that would create both the hourly and monthly plots. Added a helped function that appended the axes, title, and labels. Also brought all the const to the top. 

Fixes #3. Fixes #4. Fixes #6 